### PR TITLE
[minor] cambio X e H in x e h

### DIFF
--- a/conv_deconv.md
+++ b/conv_deconv.md
@@ -17,7 +17,7 @@ Per il sistema `s` vale:
 Il processo di convoluzione viene utilizzato nel calcolo dell'uscita di un
 sistema di filtri digitali ([FIR](https://it.wikipedia.org/wiki/Finite_impulse_response), [IIR](https://it.wikipedia.org/wiki/Infinite_impulse_response)).
 
-Sia `X(n)` il segnale d'ingresso ed `H(n)` la risposta impulsiva del sistema, entrambe
+Sia `x(n)` il segnale d'ingresso ed `h(n)` la risposta impulsiva del sistema, entrambe
 nel dominio temporale, abbiamo che il segnale di uscita è dato dalla seguente
 relazione:
 


### PR DESCRIPTION
il segnale nel dominio del tempo viene rappresentato con caratteri minuscole.
E anche dopo vengo usate x e h.
Spero che non sbaglio. 
